### PR TITLE
update SSL cert used by CloudFront

### DIFF
--- a/cicd/config.ini
+++ b/cicd/config.ini
@@ -66,7 +66,7 @@ MAX_AGE = 30
 # cloudfront
 SUB_DOMAIN = avsb-staging
 HOSTED_ZONE = ala.org.au
-SSL_CERTIFICATE = arn:aws:acm:us-east-1:736913556139:certificate/529da40c-8d50-4776-a34c-2df0e5e57cce
+SSL_CERTIFICATE = arn:aws:acm:us-east-1:736913556139:certificate/4b62cca2-9daf-4e38-b01a-48271ab3311a
 DOCUMENT_ROOT = index.html 
 
 [production]
@@ -86,5 +86,5 @@ MAX_AGE = 300
 # cloudfront
 SUB_DOMAIN = avsb-production
 HOSTED_ZONE = ala.org.au
-SSL_CERTIFICATE = arn:aws:acm:us-east-1:736913556139:certificate/529da40c-8d50-4776-a34c-2df0e5e57cce
+SSL_CERTIFICATE = arn:aws:acm:us-east-1:736913556139:certificate/4b62cca2-9daf-4e38-b01a-48271ab3311a
 DOCUMENT_ROOT = index.html 


### PR DESCRIPTION
update to an AWS issued auto renewing SSL cert for staging and production