### PR TITLE
ensure jinja2 is installed in the codebuild container

### DIFF
--- a/cicd/pipeline/export_config_buildspec.yaml
+++ b/cicd/pipeline/export_config_buildspec.yaml
@@ -23,6 +23,7 @@ phases:
       -  #echo setting up build environment
       - echo Running on $(lsb_release -d | cut -f2)
       - echo aws-cli version $(aws --version)
+      - pip install --upgrade jinja2
     finally:
       -  #echo This always runs even if the update or install command fails
       -  #notify Slack on failure


### PR DESCRIPTION
the ExportConfig pipeline action was failing because it was missing a Python library `jinja2` They must have stopped including that by default in the build container

```
[Container] 2024/04/07 19:22:46.365452 Running command cicd/pipeline/gen_template_config.py  --template cicd/pipeline/template_config.j2 > cicd/pipeline/template_config.json
--
ModuleNotFoundError: No module named 'jinja2'
```