### PR TITLE
#83 Migrated to new sensitive API

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -49,7 +49,7 @@ const routes = createBrowserRouter([
 
           return defer({
             taxon,
-            sds: await sdsAPI.get(taxon.classification.scientificName),
+            sds: await sdsAPI.get(params.guid),
             traits: austraitsAPI.summary(taxon.classification.scientificName, params.guid || ''),
           });
         },

--- a/src/api/sources/sds.ts
+++ b/src/api/sources/sds.ts
@@ -30,7 +30,9 @@ async function get(guid?: string): Promise<SDSInstance[]> {
   try {
     return (
       await Promise.all(
-        ['QLD', 'NT', 'NSW', 'WA', 'SA', 'ACT'].map((state) => getInstances(guid, state)),
+        ['QLD', 'NT', 'NSW', 'WA', 'SA', 'ACT', 'VIC', 'TAS'].map((state) =>
+          getInstances(guid, state),
+        ),
       )
     ).flat();
   } catch (error) {

--- a/src/api/sources/sds.ts
+++ b/src/api/sources/sds.ts
@@ -1,5 +1,7 @@
 interface SDSInstance {
-  locationGeneralisation: string;
+  generalisation: {
+    generalisation: string;
+  };
   zone: {
     name: string;
     type: string;
@@ -12,36 +14,27 @@ interface SDSInstance {
   };
 }
 
-interface SDSResult {
-  acceptedName: string | null;
-  commonName: string | null;
-  instances: SDSInstance[];
-  scientificName: string;
-  status: string[];
+async function getInstances(guid: string, state: string) {
+  const URL = `${
+    import.meta.env.VITE_API_ALA
+  }/sensitive/api/report?taxonId=${guid}&stateProvince=${state}&country=AUS`;
+  const { sensitive, valid, report } = await (await fetch(URL)).json();
+
+  return valid && sensitive ? report.taxon.instances : [];
 }
 
-async function get(
-  scientificName: string,
-  latitude?: number,
-  longitude?: number,
-  date?: string,
-): Promise<SDSResult> {
-  let URL = `${import.meta.env.VITE_API_ALA}/sds-webapp/ws/${scientificName}`;
-
-  // Append optional lat/lng parameters
-  if (latitude !== undefined && longitude !== undefined)
-    URL += `/location/${latitude}/${longitude}`;
-
-  // Append optional date parameters
-  if (date !== undefined) URL += `/date/${date}`;
+async function get(guid?: string): Promise<SDSInstance[]> {
+  if (!guid) return [];
 
   // Wrap in a try-catch to handle
   try {
-    const data = await (await fetch(URL)).json();
-    if (!data.instances) throw new Error('Invalid request');
-    return data;
+    return (
+      await Promise.all(
+        ['QLD', 'NT', 'NSW', 'WA', 'SA', 'ACT'].map((state) => getInstances(guid, state)),
+      )
+    ).flat();
   } catch (error) {
-    return { acceptedName: null, commonName: null, scientificName: '', status: [], instances: [] };
+    return [];
   }
 }
 
@@ -49,4 +42,4 @@ export default {
   get,
 };
 
-export type { SDSInstance, SDSResult };
+export type { SDSInstance };

--- a/src/components/AccessionPanel/index.tsx
+++ b/src/components/AccessionPanel/index.tsx
@@ -47,12 +47,12 @@ import {
 
 // Project imports
 import {
-  SDSResult,
   Event,
   SeedBankAccession,
   AusTraitsSummary,
   NumericTrait,
   CategoricalTrait,
+  SDSInstance,
 } from '#/api';
 import { getIsDefined, accessionFields, SeedbankFieldTrait } from '#/helpers';
 
@@ -146,7 +146,7 @@ interface AccessionPanelLoader {
 }
 
 interface RouteLoaderProps {
-  sds: SDSResult;
+  sds: SDSInstance[];
   traits: AusTraitsSummary;
 }
 

--- a/src/views/Accessions/index.tsx
+++ b/src/views/Accessions/index.tsx
@@ -10,7 +10,6 @@ import {
 
 // Project components / helpers
 import {
-  SDSResult,
   gqlQueries,
   performGQLQuery,
   Taxon,
@@ -41,7 +40,7 @@ export function Component() {
   const [pageSize, setPageSize] = useState<number>(10);
   const [query, setQuery] = useState<EventDocuments>(useLoaderData() as EventDocuments);
 
-  const { taxon } = useRouteLoaderData('taxon') as { taxon: Taxon; sds: SDSResult | null };
+  const { taxon } = useRouteLoaderData('taxon') as { taxon: Taxon };
   const params = useParams();
   const mounted = useMounted();
   const events = query?.results;

--- a/src/views/Summary/index.tsx
+++ b/src/views/Summary/index.tsx
@@ -24,14 +24,14 @@ import { IconAlertTriangle, IconExternalLink, IconMap } from '@tabler/icons';
 import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 import { Taxon } from '#/api/sources/taxon';
 import { ConservationStatus, SDS } from '#/components';
-import { SDSResult } from '#/api';
+import { SDSInstance } from '#/api';
 
 const EventMap = lazy(() => import('#/components/EventMap'));
 
 // eslint-disable-next-line import/prefer-default-export
 export function Component() {
   const [mapOpen, { open, close }] = useDisclosure(false);
-  const { taxon, sds } = useRouteLoaderData('taxon') as { taxon: Taxon; sds: SDSResult };
+  const { taxon, sds } = useRouteLoaderData('taxon') as { taxon: Taxon; sds: SDSInstance[] };
   const token = useLoaderData() as string;
   const theme = useMantineTheme();
   const mdOrLarger = useMediaQuery(`(min-width: ${theme.breakpoints.md})`, true);
@@ -74,7 +74,7 @@ export function Component() {
             </Grid.Col>
           )}
         <Grid.Col sm={12} md={7} lg={8}>
-          {sds.instances.length > 0 ? (
+          {sds.length > 0 ? (
             <Card
               style={{ display: 'flex', alignItems: 'center' }}
               shadow='lg'
@@ -82,7 +82,7 @@ export function Component() {
               miw={345}
               withBorder
             >
-              <SDS instances={sds.instances} />
+              <SDS instances={sds} />
             </Card>
           ) : (
             <>

--- a/src/views/Trials/index.tsx
+++ b/src/views/Trials/index.tsx
@@ -5,7 +5,7 @@ import { useLoaderData, useLocation, useParams, useRouteLoaderData } from 'react
 // Project components / helpers
 import { Downloads, Filters } from '#/components';
 import { Taxon } from '#/api/sources/taxon';
-import { SDSResult, gqlQueries, performGQLQuery } from '#/api';
+import { gqlQueries, performGQLQuery } from '#/api';
 import { Event, EventDocuments, EventSearchResult, Predicate } from '#/api/graphql/types';
 import queries from '#/api/queries';
 import { useMounted, mapTrialTreatments } from '#/helpers';
@@ -26,7 +26,7 @@ export function Component() {
   const [pageSize, setPageSize] = useState<number>(10);
   const [query, setQuery] = useState<EventDocuments>(useLoaderData() as EventDocuments);
 
-  const { taxon } = useRouteLoaderData('taxon') as { taxon: Taxon; sds: SDSResult };
+  const { taxon } = useRouteLoaderData('taxon') as { taxon: Taxon };
   const params = useParams();
   const mounted = useMounted();
   const events = query?.results;


### PR DESCRIPTION
The SDS now points to the [new sensitive data service](https://docs.ala.org.au/openapi/index.html?urls.primaryName=sensitive) (`/sensitive/api`) for sensitive species requests.

As the new API does not provide functionality to retrieve an aggregated list of state-based sensitive `instances`, this new implementation rather calls the `/report?taxonId=${guid}&stateProvince=${state}&country=AUS` for each state in parallel to retrieve these instances:

```js
async function getInstances(guid: string, state: string) {
  const URL = `${
    import.meta.env.VITE_API_ALA
  }/sensitive/api/report?taxonId=${guid}&stateProvince=${state}&country=AUS`;
  const { sensitive, valid, report } = await (await fetch(URL)).json();

  return valid && sensitive ? report.taxon.instances : [];
}

await Promise.all(
  ['QLD', 'NT', 'NSW', 'WA', 'SA', 'ACT'].map((state) => getInstances(guid, state)),
)
```