### PR TITLE
Feature/cicd update

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ALA Bedrock CloudFormation Dev",
+  "name": "Seedbank CloudFormation Dev",
   "build": {
     "dockerfile": "Dockerfile"
   },
@@ -48,6 +48,7 @@
                 "!If sequence",
                 "!ImportValue scalar",
                 "!ImportValue sequence",
+                "!ImportValue mapping",
                 "!Join sequence",
                 "!Not sequence",
                 "!Or sequence",

--- a/cicd/frontend/pipeline/deploy_notification_buildspec.yaml
+++ b/cicd/frontend/pipeline/deploy_notification_buildspec.yaml
@@ -18,6 +18,8 @@ phases:
     commands:
       - echo Running on $(lsb_release -d | cut -f2)
       - echo aws-cli version $(aws --version)
+      - echo loading all exported vars..
+      - set -a ; source env.txt ; set +a
     finally:
       - #echo This always runs even if the update or install command fails
 

--- a/cicd/frontend/pipeline/empty_bucket_buildspec.yaml
+++ b/cicd/frontend/pipeline/empty_bucket_buildspec.yaml
@@ -1,6 +1,6 @@
 version: 0.2
 ###
-# Deletes all objects from the source bucket, this needs to be done 
+# Deletes all objects from the source bucket, this needs to be done
 # before publish so that old files are removed and before the teardown action
 # so the bucket can be removed
 
@@ -8,6 +8,12 @@ env:
   shell: bash
 
 phases:
+  install:
+    commands:
+      - echo Running on $(lsb_release -d | cut -f2)
+      - echo aws-cli version $(aws --version)
+      - echo loading all exported vars..
+      - set -a ; source env.txt ; set +a
   build:
     commands:
       - echo source bucket is $SOURCE_BUCKET/$BUCKET_PATH

--- a/cicd/frontend/pipeline/export_config_buildspec.yaml
+++ b/cicd/frontend/pipeline/export_config_buildspec.yaml
@@ -13,17 +13,9 @@ env:
     - APP_STACK_FILE_PFIX
     - APP_STACK_NAME
     - BUCKET_PATH
-    - CODEBUILD_BUILD_NUMBER
-    - ENVIRONMENT
-    - HOSTED_ZONE
     - MAX_AGE
     - NODE_VERSION
-    - PRODUCT_COMPONENT
-    - PRODUCT_NAME
-    - SLACK_ALERT_CHANNEL
-    - SLACK_DEPLOY_NOTIFICATION
     - SOURCE_BUCKET
-    - SUB_DOMAIN
     - WAF_STACK_FILE_PFIX
     - WAF_STACK_NAME
 
@@ -42,12 +34,12 @@ phases:
       - # we need to run a specific commit, not the latest. In this case the pipeline is set NOT to
       - # autorun on update. It will have to be manually started after the rollback pipeline
       - # has finished launching
-      - | 
+      - |
           if [[ $PIPELINE_FINGERPRINT != $CUR_PIPELINE_FINGERPRINT ]]; then
             echo existing pipeline is out of sync with current code revision, relaunching!
             cd cicd/$PRODUCT_COMPONENT/pipeline/
             ./deploy_pipeline.sh -e ${ENVIRONMENT:0:4} -b $SRC_BRANCH
-            # pipeline execution should now stop if this is a rollback, 
+            # pipeline execution should now stop if this is a rollback,
             # or restart automatically if this a normal branch deploy
             exit 1
           else
@@ -63,6 +55,11 @@ phases:
       - echo clean branch is $CLEAN_BRANCH
       - echo Environment is $ENVIRONMENT
       - cicd/gen_env_vars.py --env $ENVIRONMENT --clean-branch $CLEAN_BRANCH --conf cicd/$PRODUCT_COMPONENT/config.ini > env.txt
+      - echo EXECUTION_ID=$EXECUTION_ID >> env.txt
+      - echo AUTHOR=\"$AUTHOR\" >> env.txt
+      - echo SRC_BRANCH=$SRC_BRANCH >> env.txt
+      - echo COMMIT_ID=$COMMIT_ID >> env.txt
+      - echo REPO=$REPO >> env.txt
       - echo loading config..
       - set -a ; source env.txt ; set +a
     finally:
@@ -93,5 +90,8 @@ phases:
 artifacts:
   files:
     - cicd/$PRODUCT_COMPONENT/app/*
+    - cicd/$PRODUCT_COMPONENT/pipeline/*
+    - cicd/*
+    - env.txt
   name: BuildTemplateConfigArtifact
   discard-paths: no

--- a/cicd/frontend/pipeline/npm_build_buildspec.yaml
+++ b/cicd/frontend/pipeline/npm_build_buildspec.yaml
@@ -11,6 +11,10 @@ phases:
     runtime-versions:
       nodejs: $NODE_VERSION
     commands:
+      - echo Running on $(lsb_release -d | cut -f2)
+      - echo aws-cli version $(aws --version)
+      - echo loading all exported vars..
+      - set -a ; source env.txt ; set +a
       - echo updating corepack...
       - npm install --global corepack@latest
       - echo installing pnpm...

--- a/cicd/frontend/pipeline/npm_build_buildspec.yaml
+++ b/cicd/frontend/pipeline/npm_build_buildspec.yaml
@@ -14,7 +14,7 @@ phases:
       - echo Running on $(lsb_release -d | cut -f2)
       - echo aws-cli version $(aws --version)
       - echo loading all exported vars..
-      - set -a ; source env.txt ; set +a
+      - set -a ; source "$CODEBUILD_SRC_DIR_ExportConfigArtifact/env.txt" ; set +a
       - echo updating corepack...
       - npm install --global corepack@latest
       - echo installing pnpm...

--- a/cicd/frontend/pipeline/pipeline.yaml
+++ b/cicd/frontend/pipeline/pipeline.yaml
@@ -336,13 +336,15 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref BuildCode
-                EnvironmentVariables: !Sub |
+                PrimarySource: AvsbSourceArtifact
+                EnvironmentVariables: |
                   [
                    { "name": "NODE_VERSION", "value":"#{ExportConfigNS.NODE_VERSION}" },
                   ]
               Namespace: BuildAvsbNS
               InputArtifacts:
                 - Name: AvsbSourceArtifact
+                - Name: ExportConfigArtifact
               OutputArtifacts:
                 - Name: BuildAvsbArtifact
               RunOrder: 1

--- a/cicd/frontend/pipeline/pipeline.yaml
+++ b/cicd/frontend/pipeline/pipeline.yaml
@@ -101,11 +101,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:7.0
-        EnvironmentVariables:
-          - Name: ARTIFACTS_BUCKET
-            Value: !ImportValue
-              Fn::Sub: ${pBucketsStackName}-${AWS::Region}-CodePipelineArtifactBucketName
+        Image: aws/codebuild/standard:8.0
       Source:
         Type: CODEPIPELINE
         BuildSpec: !Sub cicd/${pProductComponent}/pipeline/export_config_buildspec.yaml
@@ -128,7 +124,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:7.0
+        Image: aws/codebuild/standard:8.0
       Source:
         Type: CODEPIPELINE
         BuildSpec: !Sub cicd/${pProductComponent}/pipeline/npm_build_buildspec.yaml
@@ -151,7 +147,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:7.0
+        Image: aws/codebuild/standard:8.0
       Source:
         Type: CODEPIPELINE
         BuildSpec: !Sub cicd/${pProductComponent}/pipeline/empty_bucket_buildspec.yaml
@@ -174,10 +170,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:7.0
-        EnvironmentVariables:
-          - Name: CLEAN_BRANCH
-            Value: !Ref pCleanBranch
+        Image: aws/codebuild/standard:8.0
       Source:
         Type: CODEPIPELINE
         BuildSpec: !Sub cicd/${pProductComponent}/pipeline/deploy_notification_buildspec.yaml
@@ -261,15 +254,23 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref ExportConfig
-                EnvironmentVariables: !Sub |
-                  [
-                    { "name":"CLEAN_BRANCH", "value":"${pCleanBranch}" },
-                    { "name":"COMMIT_ID", "value":"#{CheckoutSrcNS.CommitId}" },
-                    { "name":"ENVIRONMENT", "value":"${pEnvironment}" },
-                    { "name":"PIPELINE_FINGERPRINT", "value":"#{variables.PIPELINE_FINGERPRINT}" },
-                    { "name":"PRODUCT_COMPONENT", "value":"${pProductComponent}" },
-                    { "name":"SRC_BRANCH", "value":"#{CheckoutSrcNS.BranchName}" }
-                  ]
+                EnvironmentVariables: !Sub
+                  - |
+                    [
+                     { "name": "ARTIFACTS_BUCKET", "value":"${ArtifactsBucket}" },
+                     { "name": "AUTHOR", "value": "#{CheckoutSrcNS.AuthorDisplayName}" },
+                     { "name": "CLEAN_BRANCH", "value":"${pCleanBranch}" },
+                     { "name": "COMMIT_ID", "value":"#{CheckoutSrcNS.CommitId}" },
+                     { "name": "ENVIRONMENT", "value":"${pEnvironment}" },
+                     { "name": "EXECUTION_ID", "value":"#{codepipeline.PipelineExecutionId}" },
+                     { "name": "PIPELINE_FINGERPRINT", "value":"#{variables.PIPELINE_FINGERPRINT}" },
+                     { "name": "PRODUCT_COMPONENT", "value":"${pProductComponent}" },
+                     { "name": "PRODUCT_NAME", "value":"${pProductName}" },
+                     { "name": "REPO", "value":"#{CheckoutSrcNS.FullRepositoryName}" },
+                     { "name": "SRC_BRANCH", "value":"${pGitHubBranch}" }
+                    ]
+                  - ArtifactsBucket: !ImportValue
+                      Fn::Sub: ${pBucketsStackName}-${AWS::Region}-CodePipelineArtifactBucketName
               Namespace: ExportConfigNS
               InputArtifacts:
                 - Name: AvsbSourceArtifact
@@ -335,12 +336,9 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref BuildCode
-                EnvironmentVariables: |
+                EnvironmentVariables: !Sub |
                   [
-                    { "name":"SRC_BRANCH", "value":"#{CheckoutSrcNS.BranchName}" },
-                    { "name":"ENVIRONMENT", "value":"#{ExportConfigNS.ENVIRONMENT}" },
-                    { "name":"NODE_VERSION", "value":"#{ExportConfigNS.NODE_VERSION}" },
-                    { "name":"COMMIT_ID", "value":"#{CheckoutSrcNS.CommitId}" }
+                   { "name": "NODE_VERSION", "value":"#{ExportConfigNS.NODE_VERSION}" },
                   ]
               Namespace: BuildAvsbNS
               InputArtifacts:
@@ -356,14 +354,9 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref EmptyBucket
-                EnvironmentVariables: |
-                  [
-                    { "name":"SOURCE_BUCKET", "value":"#{ExportConfigNS.SOURCE_BUCKET}" },
-                    { "name":"BUCKET_PATH", "value":"#{ExportConfigNS.BUCKET_PATH}" }
-                  ]
               Namespace: EmptyBucketPreDeployNS
               InputArtifacts:
-                - Name: AvsbSourceArtifact
+                - Name: ExportConfigArtifact
               RunOrder: 2
             - Name: UploadFilesToS3
               ActionTypeId:
@@ -378,7 +371,7 @@ Resources:
                 CacheControl: public, max-age=#{ExportConfigNS.MAX_AGE}
               OutputArtifacts: []
               InputArtifacts:
-                - Name: BuildAvsbArtifact
+                - Name: ExportConfigArtifact
               RunOrder: 3
             - Name: DeployNotification
               ActionTypeId:
@@ -388,25 +381,9 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref DeployNotification
-                EnvironmentVariables: !Sub |
-                  [
-                    { "name":"AUTHOR", "value":"#{CheckoutSrcNS.AuthorDisplayName}" },
-                    { "name":"CLEAN_BRANCH", "value":"${pCleanBranch}" },
-                    { "name":"COMMIT_ID", "value":"#{CheckoutSrcNS.CommitId}" },
-                    { "name":"ENVIRONMENT", "value":"${pEnvironment}" },
-                    { "name":"EXECUTION_ID", "value":"#{codepipeline.PipelineExecutionId}" },
-                    { "name":"HOSTED_ZONE", "value":"#{ExportConfigNS.HOSTED_ZONE}" },
-                    { "name":"PRODUCT_COMPONENT", "value":"#{ExportConfigNS.PRODUCT_COMPONENT}" },
-                    { "name":"PRODUCT_NAME", "value":"#{ExportConfigNS.PRODUCT_NAME}" },
-                    { "name":"REPO", "value":"#{CheckoutSrcNS.FullRepositoryName}" },
-                    { "name":"SLACK_ALERT_CHANNEL", "value":"#{ExportConfigNS.SLACK_ALERT_CHANNEL}" },
-                    { "name":"SLACK_DEPLOY_NOTIFICATION", "value":"#{ExportConfigNS.SLACK_DEPLOY_NOTIFICATION}" },
-                    { "name":"SRC_BRANCH", "value":"${pGitHubBranch}" },
-                    { "name":"SUB_DOMAIN", "value":"#{ExportConfigNS.SUB_DOMAIN}" }
-                  ]
               Namespace: DeployNotificationNS
               InputArtifacts:
-                - Name: AvsbSourceArtifact
+                - Name: ExportConfigArtifact
               RunOrder: 5
         - !If
           - AllowTeardown
@@ -429,14 +406,9 @@ Resources:
                   Provider: CodeBuild
                 Configuration:
                   ProjectName: !Ref EmptyBucket
-                  EnvironmentVariables: |
-                    [
-                      { "name":"SOURCE_BUCKET", "value":"#{ExportConfigNS.SOURCE_BUCKET}" },
-                      { "name":"BUCKET_PATH", "value":"#{ExportConfigNS.BUCKET_PATH}" }
-                    ]
                 Namespace: EmptyBucketPreDeleteNS
                 InputArtifacts:
-                  - Name: AvsbSourceArtifact
+                  - Name: ExportConfigArtifact
                 RunOrder: 2
               - Name: TeardownAvsbSite
                 ActionTypeId:

--- a/cicd/frontend/pipeline/pipeline.yaml
+++ b/cicd/frontend/pipeline/pipeline.yaml
@@ -373,7 +373,7 @@ Resources:
                 CacheControl: public, max-age=#{ExportConfigNS.MAX_AGE}
               OutputArtifacts: []
               InputArtifacts:
-                - Name: ExportConfigArtifact
+                - Name: AvsbSourceArtifact
               RunOrder: 3
             - Name: DeployNotification
               ActionTypeId:

--- a/cicd/frontend/pipeline/pipeline.yaml
+++ b/cicd/frontend/pipeline/pipeline.yaml
@@ -339,7 +339,7 @@ Resources:
                 PrimarySource: AvsbSourceArtifact
                 EnvironmentVariables: |
                   [
-                   { "name": "NODE_VERSION", "value":"#{ExportConfigNS.NODE_VERSION}" },
+                   { "name": "NODE_VERSION", "value":"#{ExportConfigNS.NODE_VERSION}" }
                   ]
               Namespace: BuildAvsbNS
               InputArtifacts:

--- a/cicd/frontend/pipeline/pipeline.yaml
+++ b/cicd/frontend/pipeline/pipeline.yaml
@@ -373,7 +373,7 @@ Resources:
                 CacheControl: public, max-age=#{ExportConfigNS.MAX_AGE}
               OutputArtifacts: []
               InputArtifacts:
-                - Name: AvsbSourceArtifact
+                - Name: BuildAvsbArtifact
               RunOrder: 3
             - Name: DeployNotification
               ActionTypeId:


### PR DESCRIPTION
Update CICD pipeline with the latest changes.

The main change is to pass environment variables between codebuild actions using the env.txt file generated in the export-config action. This simplifies the pipeline and the export config buildspec by removing most of the explicitly exported and imported vars. It also means when vars are added or removed they dont have to be updated on the pipeline or buildspec as they automatically exported. Additionally the pipleline will not have to be relaunched for these changes

Unfortunately it doesn't cover all situations, variables used in non codebuild actions like laucnhing CloudFormation still have to be exported and also any variables used in buildspecs before env.txt can be imported